### PR TITLE
Fix logging system

### DIFF
--- a/src/main/java/me/sat7/dynamicshop/DynamicShop.java
+++ b/src/main/java/me/sat7/dynamicshop/DynamicShop.java
@@ -184,6 +184,8 @@ public final class DynamicShop extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
         Bukkit.getScheduler().cancelTasks(this);
+        console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Checking for logs older than defined in config");
+        LogUtil.cullLogs();
         console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Disabled");
     }
 

--- a/src/main/java/me/sat7/dynamicshop/DynamicShop.java
+++ b/src/main/java/me/sat7/dynamicshop/DynamicShop.java
@@ -25,6 +25,7 @@ import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.File;
 import java.util.List;
@@ -63,6 +64,16 @@ public final class DynamicShop extends JavaPlugin implements Listener {
         setupConfigs();
         makeFolders();
         hookIntoJobs();
+
+        if (getConfig().getBoolean("CullLogs")) {
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Checking for logs older than defined in config");
+                    LogUtil.cullLogs();
+                }
+            }.runTaskTimer(this, 0L, (20L * 60L * (long) getConfig().getInt("LogCullTimeMinutes")));
+        }
 
         // 완료
         console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Enabled! :)");
@@ -184,8 +195,6 @@ public final class DynamicShop extends JavaPlugin implements Listener {
     @Override
     public void onDisable() {
         Bukkit.getScheduler().cancelTasks(this);
-        console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Checking for logs older than defined in config");
-        LogUtil.cullLogs();
         console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Disabled");
     }
 

--- a/src/main/java/me/sat7/dynamicshop/files/CustomConfig.java
+++ b/src/main/java/me/sat7/dynamicshop/files/CustomConfig.java
@@ -17,7 +17,7 @@ public class CustomConfig {
     //Finds or generates the custom config file
     public void setup(String name, String folder){
         String path = name + ".yml";
-        if(folder != null) path = folder+"\\"+path;
+        if(folder != null) path = folder+"/"+path;
         file = new File(Bukkit.getServer().getPluginManager().getPlugin("DynamicShop").getDataFolder(), path);
 
         if (!file.exists()){
@@ -32,7 +32,7 @@ public class CustomConfig {
 
     public boolean open(String name, String folder)
     {
-        file = new File(Bukkit.getServer().getPluginManager().getPlugin("DynamicShop").getDataFolder(), folder+"\\"+name + ".yml");
+        file = new File(Bukkit.getServer().getPluginManager().getPlugin("DynamicShop").getDataFolder(), folder+"/"+name + ".yml");
 
         if (!file.exists())
         {
@@ -62,7 +62,7 @@ public class CustomConfig {
 
     public static FileConfiguration GetFileFromPath(String name, String folder)
     {
-        File tempFile = new File(Bukkit.getServer().getPluginManager().getPlugin("DynamicShop").getDataFolder(), folder+"\\"+name + ".yml");
+        File tempFile = new File(Bukkit.getServer().getPluginManager().getPlugin("DynamicShop").getDataFolder(), folder+"/"+name + ".yml");
 
         if (!tempFile.exists())
         {

--- a/src/main/java/me/sat7/dynamicshop/utilities/ConfigUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/ConfigUtil.java
@@ -204,6 +204,9 @@ public final class ConfigUtil {
         if(numPlayer > 100) numPlayer = 100;
         dynamicShop.getConfig().set("NumberOfPlayer",numPlayer);
 
+        dynamicShop.getConfig().set("SaveLogs", dynamicShop.getConfig().getBoolean("SaveLogs"));
+        dynamicShop.getConfig().set("CullLogs", dynamicShop.getConfig().getBoolean("CullLogs"));
+        dynamicShop.getConfig().set("LogCullAgeMinutes", dynamicShop.getConfig().getInt("LogCullAgeMinutes"));
         dynamicShop.getConfig().set("LogCullTimeMinutes", dynamicShop.getConfig().getInt("LogCullTimeMinutes"));
 
         dynamicShop.getConfig().set("OnClickCloseButton_OpenStartPage", dynamicShop.getConfig().getBoolean("OnClickCloseButton_OpenStartPage"));

--- a/src/main/java/me/sat7/dynamicshop/utilities/ConfigUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/ConfigUtil.java
@@ -183,7 +183,6 @@ public final class ConfigUtil {
         DynamicShop.dsPrefix = dynamicShop.getConfig().getString("Prefix");
         dynamicShop.getConfig().set("UseShopCommand", dynamicShop.getConfig().getBoolean("UseShopCommand"));
         dynamicShop.getConfig().set("DefaultShopName", dynamicShop.getConfig().getString("DefaultShopName"));
-        dynamicShop.getConfig().set("DefaultShopName", dynamicShop.getConfig().getString("DefaultShopName"));
 
         try {
             Bukkit.getScheduler().cancelTask(randomStocktask.getTaskId());

--- a/src/main/java/me/sat7/dynamicshop/utilities/ConfigUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/ConfigUtil.java
@@ -183,6 +183,7 @@ public final class ConfigUtil {
         DynamicShop.dsPrefix = dynamicShop.getConfig().getString("Prefix");
         dynamicShop.getConfig().set("UseShopCommand", dynamicShop.getConfig().getBoolean("UseShopCommand"));
         dynamicShop.getConfig().set("DefaultShopName", dynamicShop.getConfig().getString("DefaultShopName"));
+        dynamicShop.getConfig().set("DefaultShopName", dynamicShop.getConfig().getString("DefaultShopName"));
 
         try {
             Bukkit.getScheduler().cancelTask(randomStocktask.getTaskId());
@@ -202,6 +203,8 @@ public final class ConfigUtil {
         if(numPlayer <= 3) numPlayer = 3;
         if(numPlayer > 100) numPlayer = 100;
         dynamicShop.getConfig().set("NumberOfPlayer",numPlayer);
+
+        dynamicShop.getConfig().set("LogCullTimeMinutes", dynamicShop.getConfig().getInt("LogCullTimeMinutes"));
 
         dynamicShop.getConfig().set("OnClickCloseButton_OpenStartPage", dynamicShop.getConfig().getBoolean("OnClickCloseButton_OpenStartPage"));
         dynamicShop.getConfig().set("OpenStartPageInsteadOfDefaultShop", dynamicShop.getConfig().getBoolean("OpenStartPageInsteadOfDefaultShop"));

--- a/src/main/java/me/sat7/dynamicshop/utilities/LogUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/LogUtil.java
@@ -1,7 +1,12 @@
 package me.sat7.dynamicshop.utilities;
 
+import java.io.File;
+import java.nio.file.attribute.FileTime;
 import java.text.SimpleDateFormat;
+import java.util.logging.Level;
 
+import me.sat7.dynamicshop.DynamicShop;
+import me.sat7.dynamicshop.constants.Constants;
 import me.sat7.dynamicshop.files.CustomConfig;
 
 public final class LogUtil {
@@ -13,7 +18,7 @@ public final class LogUtil {
 
     public static void setupLogFile()
     {
-        SimpleDateFormat sdf = new SimpleDateFormat ( "yyMMdd-HHmmss");
+        SimpleDateFormat sdf = new SimpleDateFormat ( "MM-dd-yyyy-HH:mm:ss");
         String timeStr = sdf.format (System.currentTimeMillis());
         ccLog.setup("Log_"+timeStr,"Log");
         ccLog.get().options().copyDefaults(true);
@@ -38,6 +43,27 @@ public final class LogUtil {
         if(ccLog.get().getKeys(true).size() > 500)
         {
             setupLogFile();
+        }
+    }
+
+    public static void cullLogs() {
+        SimpleDateFormat sdf = new SimpleDateFormat ( "MM-dd-yyyy-HH:mm:ss");
+        String timeStr = sdf.format (System.currentTimeMillis());
+        ccLog.setup("Log_"+timeStr,"Log");
+        ccLog.get().options().copyDefaults(true);
+        ccLog.save();
+
+
+        File[] logs = new File(DynamicShop.plugin.getDataFolder() + "/Log").listFiles();
+        if (logs.length > 0)
+        {
+            for(File l : logs) {
+                int ageMins = (int) (System.currentTimeMillis() - l.lastModified())/60000;
+                if(ageMins > DynamicShop.plugin.getConfig().getInt("LogCullTimeMinutes")) {
+                    DynamicShop.console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Deleting log file " + l.getName() + " with age " + ageMins + " minutes.");
+                    l.delete();
+                }
+            }
         }
     }
 }

--- a/src/main/java/me/sat7/dynamicshop/utilities/LogUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/LogUtil.java
@@ -47,13 +47,6 @@ public final class LogUtil {
     }
 
     public static void cullLogs() {
-        SimpleDateFormat sdf = new SimpleDateFormat ( "MM-dd-yyyy-HH:mm:ss");
-        String timeStr = sdf.format (System.currentTimeMillis());
-        ccLog.setup("Log_"+timeStr,"Log");
-        ccLog.get().options().copyDefaults(true);
-        ccLog.save();
-
-
         File[] logs = new File(DynamicShop.plugin.getDataFolder() + "/Log").listFiles();
         if (logs.length > 0)
         {

--- a/src/main/java/me/sat7/dynamicshop/utilities/LogUtil.java
+++ b/src/main/java/me/sat7/dynamicshop/utilities/LogUtil.java
@@ -18,31 +18,35 @@ public final class LogUtil {
 
     public static void setupLogFile()
     {
-        SimpleDateFormat sdf = new SimpleDateFormat ( "MM-dd-yyyy-HH:mm:ss");
-        String timeStr = sdf.format (System.currentTimeMillis());
-        ccLog.setup("Log_"+timeStr,"Log");
-        ccLog.get().options().copyDefaults(true);
-        ccLog.save();
+        if(DynamicShop.plugin.getConfig().getBoolean("SaveLogs")) {
+            SimpleDateFormat sdf = new SimpleDateFormat ( "MM-dd-yyyy-HH:mm:ss");
+            String timeStr = sdf.format (System.currentTimeMillis());
+            ccLog.setup("Log_"+timeStr,"Log");
+            ccLog.get().options().copyDefaults(true);
+            ccLog.save();
+        }
     }
 
     // 거래 로그 기록
     public static void addLog(String shopName, String itemName, int amount, double value, String curr, String player)
     {
-        if(ShopUtil.ccShop.get().contains(shopName+".Options.log") && ShopUtil.ccShop.get().getBoolean(shopName+".Options.log"))
-        {
-            SimpleDateFormat sdf = new SimpleDateFormat ( "yyMMdd,HHmmss");
-            String timeStr = sdf.format (System.currentTimeMillis());
+        if(DynamicShop.plugin.getConfig().getBoolean("SaveLogs")) {
+            if(ShopUtil.ccShop.get().contains(shopName+".Options.log") && ShopUtil.ccShop.get().getBoolean(shopName+".Options.log"))
+            {
+                SimpleDateFormat sdf = new SimpleDateFormat ( "yyMMdd,HHmmss");
+                String timeStr = sdf.format (System.currentTimeMillis());
 
-            int i = 0;
-            if(ccLog.get().contains(shopName)) i = ccLog.get().getConfigurationSection(shopName).getKeys(false).size();
+                int i = 0;
+                if(ccLog.get().contains(shopName)) i = ccLog.get().getConfigurationSection(shopName).getKeys(false).size();
 
-            ccLog.get().set(shopName+"."+i,timeStr +","+itemName + "," + amount + "," + Math.round(value*100)/100.0 + "," + curr+","+player);
-            ccLog.save();
-        }
+                ccLog.get().set(shopName+"."+i,timeStr +","+itemName + "," + amount + "," + Math.round(value*100)/100.0 + "," + curr+","+player);
+                ccLog.save();
+            }
 
-        if(ccLog.get().getKeys(true).size() > 500)
-        {
-            setupLogFile();
+            if(ccLog.get().getKeys(true).size() > 500)
+            {
+                setupLogFile();
+            }
         }
     }
 
@@ -52,7 +56,7 @@ public final class LogUtil {
         {
             for(File l : logs) {
                 int ageMins = (int) (System.currentTimeMillis() - l.lastModified())/60000;
-                if(ageMins > DynamicShop.plugin.getConfig().getInt("LogCullTimeMinutes")) {
+                if(ageMins > DynamicShop.plugin.getConfig().getInt("LogCullAgeMinutes")) {
                     DynamicShop.console.sendMessage(Constants.DYNAMIC_SHOP_PREFIX + " Deleting log file " + l.getName() + " with age " + ageMins + " minutes.");
                     l.delete();
                 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,5 +6,6 @@ DefaultShopName: Main
 DisplayStockAsStack: false
 DeliveryChargeScale: 1
 NumberOfPlayer: 10
+LogCullTimeMinutes: 7200
 OnClickCloseButton_OpenStartPage: true
 OpenStartPageInsteadOfDefaultShop: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,9 @@ DefaultShopName: Main
 DisplayStockAsStack: false
 DeliveryChargeScale: 1
 NumberOfPlayer: 10
-LogCullTimeMinutes: 7200
+SaveLogs: true
+CullLogs: true
+LogCullAgeMinutes: 7200
+LogCullTimeMinutes: 120
 OnClickCloseButton_OpenStartPage: true
 OpenStartPageInsteadOfDefaultShop: false


### PR DESCRIPTION
- Add an option whether to save logs (if no shops have logging on, turn this off to avoid tons of empty log files)
- Delete logs older than an amount of minutes set in config. Checks for old files every X minutes (defined in config) Can be turned off in config.
- Fix log files being put in the root plugin config folder, not inside the log folder on non-windows systems